### PR TITLE
Add Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ Unrar.prototype.list = function (done) {
 
   self._exec(['vt'], function (err, stdout) {
     if (err) { return done(err); }
-    var chunks = stdout.split('\n\n');
+    var chunks = stdout.split(/\r?\n\r?\n/);
     chunks = chunks.slice(2, chunks.length - 1);
     var list = chunks.map(extractProps);
     done(null, list);
@@ -74,7 +74,7 @@ Unrar.prototype._exec = function (args, done) {
 function extractProps (raw) {
   var desc = {};
 
-  var props = raw.split('\n');
+  var props = raw.split(/\r?\n/);
   props.forEach(function (prop) {
     prop = prop.split(': ');
     var key = normalizeKey(prop[0]);


### PR DESCRIPTION
When using Unrar for Windows, the list output's line feeds are `\r\n` instead of `\n`. This results in `node-unrar` always returning empty results for listings.

This PR replaces the split string with a regex that works on both Windows and Linux.